### PR TITLE
Remove winter weather banner from home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Carousel from "@/components/Carousel";
-import ClosureBanner from "@/components/ClosureBanner";
 import { FacebookIcon, InstagramIcon } from "@/components/icons";
 import { trackSocialClick } from "@/lib/analytics";
 
@@ -29,9 +28,6 @@ export default function Home() {
 
   return (
     <>
-      {/* Closure Banner */}
-      <ClosureBanner />
-
       {/* Image Slider */}
       <Carousel slides={slides} />
 


### PR DESCRIPTION
Keep ClosureBanner component for future use but remove it from display.

Closes #6

Generated with [Claude Code](https://claude.ai/code)