### PR TITLE
Add back closure banner with generic message

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { quicheRegular, quicheBold } from "@/lib/fonts";
 import Navigation from "@/components/Navigation";
 import Footer from "@/components/Footer";
+import ClosureBanner from "@/components/ClosureBanner";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import "./globals.css";
@@ -24,6 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${quicheRegular.variable} ${quicheBold.variable}`}>
+        <ClosureBanner />
         <Navigation />
         {children}
         <Footer />

--- a/src/components/ClosureBanner.tsx
+++ b/src/components/ClosureBanner.tsx
@@ -5,10 +5,7 @@ export default function ClosureBanner() {
     <div className="bg-red-600 text-white py-4 px-6 text-center">
       <div className="container mx-auto">
         <p className="text-lg sm:text-xl md:text-2xl font-semibold">
-          ⚠️ Closed Today Due to Winter Weather
-        </p>
-        <p className="text-sm sm:text-base md:text-lg mt-1">
-          We apologize for the inconvenience. Stay safe and warm!
+          ⚠️ Closed Today - Sorry for the Inconvenience
         </p>
       </div>
     </div>


### PR DESCRIPTION
Fixes #9

Added back the closure banner with updated generic message:
- Updated ClosureBanner component to display "Closed Today - Sorry for the Inconvenience"
- Removed all winter weather specific text
- Added ClosureBanner to layout to display on all pages

Generated with [Claude Code](https://claude.ai/code)